### PR TITLE
Fix validation error for when flag is unknown

### DIFF
--- a/src/binary_cookies_parser/parser.py
+++ b/src/binary_cookies_parser/parser.py
@@ -6,7 +6,7 @@ from typing import List
 from binary_cookies_parser.models import BcField, Cookie, CookieFields, FileFields, Flag, Format
 
 FLAGS = {
-    0: "",
+    0: Flag.UNKNOWN,
     1: Flag.SECURE,
     4: Flag.HTTPONLY,
     5: Flag.SECURE_HTTPONLY,


### PR DESCRIPTION
Returning an empty string when flag is unknown causes a "ValidationError: 1 validation error for Cookie" error. 

This fixes it by returning a Flag.UNKNOWN in such case, as expected.