### PR TITLE
Avoid invalid JSON wrapping from `rich.print`

### DIFF
--- a/src/binarycookies/__main__.py
+++ b/src/binarycookies/__main__.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from enum import Enum
+from sys import stdout
 from typing import Type
 
 import typer
@@ -26,7 +27,7 @@ def cli(file_path: str, output: str = "json"):
     with open(file_path, "rb") as f:
         cookies = load(f)
     if output == OutputType.json:
-        print(json.dumps([cookie.model_dump() for cookie in cookies], indent=2, cls=DateTimeEncoder))
+        json.dump([cookie.model_dump() for cookie in cookies], indent=2, cls=DateTimeEncoder, fp=stdout)
     elif output == OutputType.ascii:
         for cookie in cookies:
             print(f"Name: {cookie.name}")


### PR DESCRIPTION
Using `rich.print` will wrap based on the terminal's `COLUMNS` setting. For long cookies, this will result in invalid JSON, as reported by `jq`.

Changing the value of `COLUMNS` in the environment demonstrates this effect (that is, insertion of `\n` characters in the middle of long cookie values):

```
✦ ❮ for c in 80 800 8000; do COLUMNS=$c bcparser ~/tmp/Cookies.binarycookies | jq length ; done
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 6, column 39
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 1293, column 2
1191
```

There is no need to use `print` at all for JSON output; instead, we can use `dump` with a file pointer.

An alternative demonstration can be done using ordinary system `print` instead of `rich.print`.